### PR TITLE
RF_POM | footerPage.spec | ТС 02.1.21 Verify that the "Search Terms" …

### DIFF
--- a/pages/advancedSearchPage.js
+++ b/pages/advancedSearchPage.js
@@ -1,0 +1,5 @@
+export default class AndvancedSearchPage {
+    constructor (page) {
+        this.page = page
+    }
+}

--- a/pages/homePage.js
+++ b/pages/homePage.js
@@ -11,7 +11,9 @@ import NotesPage from "./notesPage";
 import ParticeAPIPage from "./particeApi.Page";
 import WriteForUsPage  from "./writeForUsPage";
 import SubscribePage from "./subscribePage";
-import PolicyPage from "./policyPage"
+import PolicyPage from "./policyPage";
+import SearchtermsPage from "./searchTermsPage";
+import AndvancedSearchPage from "./advancedSearchPage";
 
 export class HomePage {
 
@@ -35,7 +37,8 @@ export class HomePage {
 		 this.forUsLink = page.getByRole('link', { name: 'Write for us' });
 		 this.subscribeLink = page.getByRole('link', { name: 'Subscribe' });
 		 this.privacyCookiesLink = page.getByRole('link', { name: 'Privacy and Cookie Policy' });
-		 this.searchTermsLink = page.getByRole('link', { name: 'Search Terms' }),
+		 this.searchTermsLink = page.getByRole('link', { name: 'Search Terms' });
+		 this.advancedSearchLink = page.getByRole('link', { name: 'Advanced Search' });
 
 
 
@@ -47,6 +50,7 @@ export class HomePage {
 		this.gearLink = page.getByRole('menuitem', { name: 'Gear' });
 		this.trainingLink = page.getByRole('menuitem', { name: 'Training' });
 		this.saleLink = page.getByRole('menuitem', { name: 'Sale' });
+
 
 
    }
@@ -153,6 +157,16 @@ export class HomePage {
 	async clickprivacyCookiesLink() {
 		await this.privacyCookiesLink.click();
 		return new PolicyPage(this.page);
+	}
+
+	async clicksearchTermsLink() {
+		await this.searchTermsLink.click();
+		return new SearchtermsPage(this.page);
+	}
+
+	async clickadvancedSearchLink() {
+		await this.advancedSearchLink.click();
+		return new AndvancedSearchPage(this.page);
 	}
 
 

--- a/pages/searchTermsPage.js
+++ b/pages/searchTermsPage.js
@@ -1,0 +1,12 @@
+export default class SearchtermsPage {
+    constructor (page) {
+        this.page = page;
+
+        this.searchTermsHeading = page.getByText('Popular Search Terms');
+        this.searchTerms = page.locator('.search-terms')
+    }
+
+    async getSearchTerms() {
+        return this.searchTerms;
+    }
+}

--- a/tests/footerPage.spec.js
+++ b/tests/footerPage.spec.js
@@ -2,6 +2,7 @@ const { test, expect } = require('@playwright/test');
 import { HomePage } from "../pages/homePage";
 import { NOTES_LINK_TEXT, NOTES_PAGE_URL, PARTICEAPI_PAGE_URL, FOR_US_LINK_URL, SUBSCRIBE_LINK_URL, POLICY_PAGE_URL, expectedMenuItems, SEARCH_TERM_LINK_URL, SEARCH_TERMS_PAGE_HEANDING_TEXT, ADVANCED_SEARCH_PAGE_URL, SEARCH_BTN_TEXT, RESULT_SEARCH_PAGE_URL, ORDERS_RESULTS_PAGE_URL, ORDERS_AND_RETURNS_PAGE_FIELDS } from "../helpers/testDataFooterPage";
 import PolicyPage from "../pages/policyPage";
+import SearchtermsPage from "../pages/searchTermsPage";
 
 
 test.describe('footerPage.spec', () => {
@@ -188,10 +189,54 @@ test.describe('footerPage.spec', () => {
 	});
 
 	test('ТС 02.1.23 Verify that the search-terms contains the pointer cursor', async ({ page }) => {
-		
+
 		await expect(homePage.searchTermsLink).toHaveCSS('cursor', 'pointer');
 
 	});
+
+	test('ТС 02.1.21 Verify that the "Search Terms" link opens the page, the user clicked on the "Search Terms" link', async ({ page }) => {
+
+		const searchTerms = await homePage.clicksearchTermsLink();
+		await expect(page).toHaveURL(SEARCH_TERM_LINK_URL);
+
+	});
+
+	test('ТС 02.1.22 Verify that the page contain a search-terms', async ({ page }) => {
+		const searchTerms = await homePage.clicksearchTermsLink();
+		await expect(searchTerms.searchTermsHeading).toBeVisible();
+		await expect(searchTerms.searchTermsHeading).toHaveText(SEARCH_TERMS_PAGE_HEANDING_TEXT);
+		await expect(searchTerms.searchTerms).toBeVisible();
+	});
+
+	test('ТС 02.1.24 Verify that  all tags on the "Popular Search Queries" page redirect to other pages', async ({ page }) => {
+		const searchTerms = await homePage.clicksearchTermsLink();
+		const tags = await searchTerms.getSearchTerms();
+		const tagsCount = await tags.count();
+
+
+		for (let i = 0; i < tagsCount; i++) {
+			await tags.nth(i).click();
+			const currentURL = page.url();
+
+			await expect(currentURL).not.toBe(SEARCH_TERM_LINK_URL);
+
+			await page.goBack();
+		}
+	});
+
+	test('ТС 02.1.25 Verify that the "Advanced Search" link is placed in the footer', async ({ page }) => {
+		const homePage = new HomePage(page);
+		await expect(homePage.advancedSearchLink).toBeVisible();
+
+	});
+
+	test('ТС 02.1.26 Verify that the "Advanced Search" link opens the page, the user clicks on the "Advanced Search" link', async ({ page }) => {
+		
+		await homePage. clickadvancedSearchLink();
+		await expect(page).toHaveURL(ADVANCED_SEARCH_PAGE_URL);
+
+	});
+
 
 
 


### PR DESCRIPTION
…link opens the page, the user clicked on the "Search Terms" link, ТС 02.1.22 Verify that the page contain a search-terms, ТС 02.1.24 Verify that  all tags on the "Popular Search Queries" page redirect to other pages, ТС 02.1.25 Verify that the "Advanced Search" link is placed in the footer, ТС 02.1.26 Verify that the "Advanced Search" link opens the page, the user clicks on the "Advanced Search" link